### PR TITLE
The 6th instruction has a strikethrough, which needs to be removed

### DIFF
--- a/assets/css/core.css
+++ b/assets/css/core.css
@@ -246,14 +246,15 @@ ul span{
     margin-bottom: 20px;
 }
 
-.li-instruct
-{
+.li-instruct {
     text-align: left;
     line-height: 1.8;
     margin-bottom: 1.5rem;
-    list-style-type: none;
+    list-style-type: disc;
+    padding-left: 20px;
     font-family: 'Raleway', sans-serif;
-    font-size:20px
+    font-size: 20px;
+    color: #e8f4ff;
 }
 
 #footerBlock {

--- a/assets/js/core.js
+++ b/assets/js/core.js
@@ -1,6 +1,6 @@
 var Exchange = function() {
 
-    let bugLeft = '5';                
+    let bugLeft = '4';                
     let gameOver = false;
     let userWon = false;
     if (localStorage.getItem('pauseTimer') === null) {

--- a/index.html
+++ b/index.html
@@ -144,13 +144,15 @@
                                        5. Switch on super beam lights
                                     </li>
                                     <li class="li-instruct">
-                                       <s>6. Start the ignition for launch boosters</s>
+                                       <li class="li-instruct">
+                                           <s>6. Start the ignition for launch boosters</s>
+                                       </li>
                                     </li>
                                     <li class="li-instruct">
                                        7. Launch
                                     </li>
                                  </ul>
-                                 <button class="btn btn-xl btn-sf btnInstruct">cadarnhau cyfarwyddiadau</button>
+                                 <button class="btn btn-xl btn-sf btnInstruct">Confirm Instructions</button>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
As a website user, I want the text formatting in the instruction guidelines to be clear and correct, so that I can easily understand and follow the provided steps without confusion.