### PR TITLE
The 6th instruction has a strikethrough, which needs to be removed

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,7 +144,7 @@
                                        5. Switch on super beam lights
                                     </li>
                                     <li class="li-instruct">
-                                       <s>6. Start the ignition for launch boosters</s>
+                                       6. Start the ignition for launch boosters
                                     </li>
                                     <li class="li-instruct">
                                        7. Launch


### PR DESCRIPTION
As a website user, I want the strikethrough removed from the 6th instruction in the instructions box, so that I can clearly understand and follow the guidance provided without confusion.