### PR TITLE
rotate the bottom left rocket ship part image 90 degrees clockwise

### DIFF
--- a/assets/css/core.css
+++ b/assets/css/core.css
@@ -285,7 +285,7 @@ ul span{
     clear: both;
     background-image: url(../img/00.png);
     background-size: cover;
-    transform:rotate(270deg);
+    transform:rotate(360deg);
     background-origin: content-box;
 }
 #top-left


### PR DESCRIPTION
Title: Correction of Rocket Ship Part Image Orientation

User Story:
As a website visitor, I want the bottom left rocket ship part image to be rotated 90 degrees clockwise, so that it matches the correct orientation for an improved visual representation.