### PR TITLE
remove the indentation from the third item in the instructions list

### DIFF
--- a/assets/js/core.js
+++ b/assets/js/core.js
@@ -1,6 +1,6 @@
 var Exchange = function() {
 
-    let bugLeft = '3';                
+    let bugLeft = '2';                
     let gameOver = false;
     let userWon = false;
     if (localStorage.getItem('pauseTimer') === null) {

--- a/index.html
+++ b/index.html
@@ -134,7 +134,7 @@
                                     <li class="li-instruct">
                                        2. Check fuel levels in engine are full
                                     </li>
-                                    <li class="li-instruct" style="text-align: center;">
+                                    <li class="li-instruct">
                                        3. Check booster rockets are fully charged
                                     </li>
                                     <li class="li-instruct">


### PR DESCRIPTION
As a website user, I want the indentation of the third item in the instructions list to be consistent with the rest of the items, so that the list appears orderly and is easy to read.