### PR TITLE
Remove the indent on the third step of the 'instructions'

### DIFF
--- a/assets/js/core.js
+++ b/assets/js/core.js
@@ -1,6 +1,6 @@
 var Exchange = function() {
 
-    let bugLeft = '2';                
+    let bugLeft = '1';                
     let gameOver = false;
     let userWon = false;
     if (localStorage.getItem('pauseTimer') === null) {

--- a/index.html
+++ b/index.html
@@ -134,7 +134,7 @@
                                     <li class="li-instruct">
                                        2. Check fuel levels in engine are full
                                     </li>
-                                    <li class="li-instruct" style="text-align: center;">
+                                    <li class="li-instruct">
                                        3. Check booster rockets are fully charged
                                     </li>
                                     <li class="li-instruct">


### PR DESCRIPTION
As a website user, I want the indent removed on the third step of the "instructions" section, so that the text aligns correctly with the other steps for a more uniform and professional appearance.