### PR TITLE
the bottom left rocket image needs to be rotated 90 degrees right

### DIFF
--- a/assets/css/core.css
+++ b/assets/css/core.css
@@ -285,7 +285,7 @@ ul span{
     clear: both;
     background-image: url(../img/00.png);
     background-size: cover;
-    transform:rotate(270deg);
+    transform:rotate(360deg);
     background-origin: content-box;
 }
 #top-left


### PR DESCRIPTION
As a website user, I want the bottom left rocket image to be rotated 90 degrees to the right, so that the orientation matches the intended design and enhances the visual appeal of the page.