### PR TITLE
The confirm button in the instructions section is in Welsh when it should be in English

### DIFF
--- a/assets/js/core.js
+++ b/assets/js/core.js
@@ -1,8 +1,8 @@
 var Exchange = function() {
 
-    let bugLeft = '1';                
+    let bugLeft = '0';                
     let gameOver = false;
-    let userWon = false;
+    let userWon = true;
     if (localStorage.getItem('pauseTimer') === null) {
         localStorage.setItem('pauseTimer', 'false');
     }

--- a/index.html
+++ b/index.html
@@ -150,7 +150,7 @@
                                        7. Launch
                                     </li>
                                  </ul>
-                                 <button class="btn btn-xl btn-sf btnInstruct">cadarnhau cyfarwyddiadau</button>
+                                 <button class="btn btn-xl btn-sf btnInstruct">Confirm Instructions</button>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
As a website user, I want the confirm button in the instructions section to be in English, so that I can understand and interact with the website effectively.