### PR TITLE
Rocket blueprint bottom left image is the wrong way around. Turn it right once 90 degrees

### DIFF
--- a/assets/css/core.css
+++ b/assets/css/core.css
@@ -285,7 +285,7 @@ ul span{
     clear: both;
     background-image: url(../img/00.png);
     background-size: cover;
-    transform:rotate(270deg);
+    transform:rotate(360deg);
     background-origin: content-box;
 }
 #top-left

--- a/assets/js/core.js
+++ b/assets/js/core.js
@@ -1,6 +1,6 @@
 var Exchange = function() {
 
-    let bugLeft = '4';                
+    let bugLeft = '3';                
     let gameOver = false;
     let userWon = false;
     if (localStorage.getItem('pauseTimer') === null) {


### PR DESCRIPTION
As a website visitor interested in rocket blueprints, I want the bottom left image of the rocket blueprint to be rotated 90 degrees to the right, so that I can accurately understand and interpret the design details of the rocket.