### PR TITLE
The main CTA for intrstuctions is wrong. It needs to be translated from welsh

### DIFF
--- a/assets/js/core.js
+++ b/assets/js/core.js
@@ -1,6 +1,6 @@
 var Exchange = function() {
 
-    let bugLeft = '2';                
+    let bugLeft = '1';                
     let gameOver = false;
     let userWon = false;
     if (localStorage.getItem('pauseTimer') === null) {

--- a/index.html
+++ b/index.html
@@ -150,7 +150,7 @@
                                        7. Launch
                                     </li>
                                  </ul>
-                                 <button class="btn btn-xl btn-sf btnInstruct">cadarnhau cyfarwyddiadau</button>
+                                 <button class="btn btn-xl btn-sf btnInstruct">Confirm Instructions</button>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
As a non-Welsh-speaking user, I want the main CTA for instructions to be translated from Welsh to English, so that I can clearly understand the instructions and navigate the website effectively.