### PR TITLE
90 degree rotation clo9ckwise - bottom left piece of rocket puzzle

### DIFF
--- a/assets/css/core.css
+++ b/assets/css/core.css
@@ -285,7 +285,7 @@ ul span{
     clear: both;
     background-image: url(../img/00.png);
     background-size: cover;
-    transform:rotate(270deg);
+    transform:rotate(360deg);
     background-origin: content-box;
 }
 #top-left

--- a/assets/js/core.js
+++ b/assets/js/core.js
@@ -1,6 +1,6 @@
 var Exchange = function() {
 
-    let bugLeft = '3';                
+    let bugLeft = '2';                
     let gameOver = false;
     let userWon = false;
     if (localStorage.getItem('pauseTimer') === null) {


### PR DESCRIPTION
User Story:
As a puzzle enthusiast, I want the bottom left piece of the rocket puzzle to be displayed already rotated 90 degrees clockwise without the need to use a rotation button, so that the puzzle piece fits accurately from the start, enhancing my experience and enjoyment in solving the puzzle.